### PR TITLE
feat: Use Profile Name

### DIFF
--- a/src/components/VideoConference/ParticipantTile/ParticipantTile.container.ts
+++ b/src/components/VideoConference/ParticipantTile/ParticipantTile.container.ts
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux'
+import { getData as getProfiles } from 'decentraland-dapps/dist/modules/profile/selectors'
+import { RootState } from '../../../modules/reducer'
+import { ParticipantTile } from './ParticipantTile'
+import type { MapStateProps } from './ParticipantTile.types'
+
+const mapStateToProps = (state: RootState): MapStateProps => {
+  return {
+    profiles: getProfiles(state)
+  }
+}
+
+export default connect(mapStateToProps)(ParticipantTile)

--- a/src/components/VideoConference/ParticipantTile/ParticipantTile.tsx
+++ b/src/components/VideoConference/ParticipantTile/ParticipantTile.tsx
@@ -16,8 +16,9 @@ import {
 } from '@livekit/components-react'
 import { Track } from 'livekit-client'
 import Profile from 'decentraland-dapps/dist/containers/Profile'
-import type { ParticipantClickEvent, TrackReferenceOrPlaceholder } from '@livekit/components-core'
-import type { Participant, TrackPublication } from 'livekit-client'
+import type { TrackReferenceOrPlaceholder } from '@livekit/components-core'
+import type { Participant } from 'livekit-client'
+import type { Props } from './ParticipantTile.types'
 
 /** @public */
 export function ParticipantContextIfNeeded(
@@ -31,16 +32,6 @@ export function ParticipantContextIfNeeded(
   ) : (
     <>{props.children}</>
   )
-}
-
-/** @public */
-export interface ParticipantTileProps extends React.HTMLAttributes<HTMLDivElement> {
-  disableSpeakingIndicator?: boolean
-  participant?: Participant
-  source?: Track.Source
-  publication?: TrackPublication
-  onParticipantClick?: (event: ParticipantClickEvent) => void
-  imageSize?: 'normal' | 'large' | 'huge' | 'massive'
 }
 
 /**
@@ -63,8 +54,9 @@ export function ParticipantTile({
   publication,
   disableSpeakingIndicator,
   imageSize,
+  profiles,
   ...htmlProps
-}: ParticipantTileProps) {
+}: Props) {
   const p = useEnsureParticipant(participant)
   const trackRef: TrackReferenceOrPlaceholder = useMaybeTrackContext() ?? {
     participant: p,
@@ -101,7 +93,7 @@ export function ParticipantTile({
   const participantWithProfile: Participant = React.useMemo(
     () => ({
       ...trackRef.participant,
-      name: 'Edita me'
+      name: profiles[trackRef.participant.identity]?.avatars[0]?.name ?? trackRef.participant.identity
     }),
     [trackRef.participant]
   ) as Participant

--- a/src/components/VideoConference/ParticipantTile/ParticipantTile.tsx
+++ b/src/components/VideoConference/ParticipantTile/ParticipantTile.tsx
@@ -95,7 +95,7 @@ export function ParticipantTile({
       ...trackRef.participant,
       name: profiles[trackRef.participant.identity]?.avatars[0]?.name ?? trackRef.participant.identity
     }),
-    [trackRef.participant]
+    [trackRef.participant, profiles]
   ) as Participant
 
   return (

--- a/src/components/VideoConference/ParticipantTile/ParticipantTile.types.ts
+++ b/src/components/VideoConference/ParticipantTile/ParticipantTile.types.ts
@@ -1,0 +1,18 @@
+import type { ParticipantClickEvent } from '@livekit/components-core'
+import type { Participant, Track, TrackPublication } from 'livekit-client'
+
+/** @public */
+export interface OwnProps extends React.HTMLAttributes<HTMLDivElement> {
+  disableSpeakingIndicator?: boolean
+  participant?: Participant
+  source?: Track.Source
+  publication?: TrackPublication
+  onParticipantClick?: (event: ParticipantClickEvent) => void
+  imageSize?: 'normal' | 'large' | 'huge' | 'massive'
+}
+
+export type Props = OwnProps & {
+  profiles: ReturnType<typeof import('decentraland-dapps/dist/modules/profile/selectors').getData>
+}
+
+export type MapStateProps = Pick<Props, 'profiles'>

--- a/src/components/VideoConference/ParticipantTile/index.tsx
+++ b/src/components/VideoConference/ParticipantTile/index.tsx
@@ -1,0 +1,3 @@
+import ParticipantTile from './ParticipantTile.container'
+
+export default ParticipantTile

--- a/src/components/VideoConference/Videoconference.tsx
+++ b/src/components/VideoConference/Videoconference.tsx
@@ -17,7 +17,7 @@ import {
   useTracks
 } from '@livekit/components-react'
 import { RoomEvent, Track } from 'livekit-client'
-import { ParticipantTile } from './ParticipantTile'
+import ParticipantTile from './ParticipantTile'
 import type { TrackReferenceOrPlaceholder, WidgetState } from '@livekit/components-core'
 
 /**

--- a/src/modules/config/env/dev.json
+++ b/src/modules/config/env/dev.json
@@ -1,6 +1,5 @@
 {
-  "NETWORK": "mainnet",
-  "CHAIN_ID": "1",
-  "PEER_URL": "https://peer.decentraland.org",
+  "CHAIN_ID": "11155111",
+  "PEER_URL": "https://peer.decentraland.zone",
   "WORLDS_CONTENT_SERVER_URL": "https://worlds-content-server.decentraland.zone"
 }

--- a/src/modules/config/env/prod.json
+++ b/src/modules/config/env/prod.json
@@ -1,5 +1,4 @@
 {
-  "NETWORK": "mainnet",
   "CHAIN_ID": "1",
   "EXPLORER_URL": "https://play.decentraland.org",
   "PEER_URL": "https://peer.decentraland.org",

--- a/src/modules/config/env/stg.json
+++ b/src/modules/config/env/stg.json
@@ -1,5 +1,4 @@
 {
-  "NETWORK": "mainnet",
   "CHAIN_ID": "1",
   "PEER_URL": "https://peer.decentraland.org",
   "WORLDS_CONTENT_SERVER_URL": "https://worlds-content-server.decentraland.org"


### PR DESCRIPTION
This PR uses the profile sagas component from `decentraland-ui` to show the user name.
 in the `ParticipantTile` component.

<img width="1717" alt="image" src="https://github.com/decentraland/cast/assets/3170051/301546c2-6390-4b84-aac0-e7490cb9b0c3">
